### PR TITLE
fix quoted headers

### DIFF
--- a/unmarshal.go
+++ b/unmarshal.go
@@ -288,6 +288,8 @@ func (d *Decoder) Decode(v interface{}) error {
 // Decoder state required to map CSV records later on.
 func (d *Decoder) DecodeHeader(line string) ([]string, error) {
 	d.headerKeys = strings.Split(line, string(d.sep))
+	d.headerKeys = maybeTrimQuotes(d.headerKeys)
+
 	if len(d.headerKeys) == 0 {
 		return nil, fmt.Errorf("csv: empty header")
 	}
@@ -559,4 +561,18 @@ func setValue(dst reflect.Value, src, fName string) error {
 		return fmt.Errorf("no method for unmarshaling type %s", dst0.Type().String())
 	}
 	return nil
+}
+
+func maybeTrimQuotes(tokens []string) []string {
+	trimmed := make([]string, 0, len(tokens))
+	for _, s := range tokens {
+		if len(s) > 0 && s[0] == '"' {
+			s = s[1:]
+		}
+		if len(s) > 0 && s[len(s)-1] == '"' {
+		    s = s[:len(s)-1]
+		}
+		trimmed = append(trimmed, s)
+	}
+	return trimmed
 }

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -79,6 +79,8 @@ func (x SpecialStruct) String() string {
 const (
 	CsvWithHeader = `s,i,f,b
 Hello,42,23.45,true`
+	CsvWithQuotedHeader = `"s","i","f","b"
+Hello,42,23.45,true`
 	CsvWithoutHeader = `Hello,true,42,23.45`
 	CsvWhitespace    = `  Hello  ,  true   ,  42  ,  23.45`
 	CsvSemicolon     = `Hello;true;42;23.45`
@@ -266,6 +268,18 @@ func CheckMap(t *testing.T, m map[string]string, b A) {
 func TestUnmarshalFromByte(t *testing.T) {
 	a := make([]*A, 0)
 	if err := Unmarshal([]byte(CsvWithHeader), &a); err != nil {
+		t.Error(err)
+	}
+	if len(a) != 1 {
+		t.Errorf("invalid record count, got=%d expected=%d", len(a), 1)
+		return
+	}
+	CheckA(t, a[0], A1)
+}
+
+func TestUnmarshalQuotedFromByte(t *testing.T) {
+	a := make([]*A, 0)
+	if err := Unmarshal([]byte(CsvWithQuotedHeader), &a); err != nil {
 		t.Error(err)
 	}
 	if len(a) != 1 {


### PR DESCRIPTION
If headers are "quoted", the internal headers are not stripped. This breaks things in some use cases.  This should allow for properly stripping quoted headers.