### PR TITLE
Don't include closing quotes in value

### DIFF
--- a/unmarshal.go
+++ b/unmarshal.go
@@ -330,7 +330,7 @@ func (d *Decoder) unmarshal(val reflect.Value, line string) error {
 			}
 		case len(v) >= 2 && strings.HasPrefix(v, Wrapper) && strings.HasSuffix(v, Wrapper):
 			// (1) .. ,"", .. (2) ..," text text ", ..
-			combined = append(combined, v[1:len(v)])
+			combined = append(combined, v[1:len(v)-1])
 			merged = ""
 		case strings.HasPrefix(v, Wrapper):
 			// .. ," text, more text", .. (1st part)

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -80,6 +80,7 @@ const (
 	CsvWithHeader = `s,i,f,b
 Hello,42,23.45,true`
 	CsvWithoutHeader = `Hello,true,42,23.45`
+	CsvQuoted        = `"Hello",true,42,23.45`
 	CsvWhitespace    = `  Hello  ,  true   ,  42  ,  23.45`
 	CsvSemicolon     = `Hello;true;42;23.45`
 	CsvComment       = `# Comment line
@@ -305,6 +306,20 @@ func TestUnmarshalNoPtr(t *testing.T) {
 
 func TestUnmarshalWithoutHeader(t *testing.T) {
 	r := bytes.NewReader([]byte(CsvWithoutHeader))
+	dec := NewDecoder(r).Header(false)
+	a := make([]*A, 0)
+	if err := dec.Decode(&a); err != nil {
+		t.Error(err)
+	}
+	if len(a) != 1 {
+		t.Errorf("invalid record count, got=%d expected=%d", len(a), 1)
+		return
+	}
+	CheckA(t, a[0], A1)
+}
+
+func TestUnmarshalQuoted(t *testing.T) {
+	r := bytes.NewReader([]byte(CsvQuoted))
 	dec := NewDecoder(r).Header(false)
 	a := make([]*A, 0)
 	if err := dec.Decode(&a); err != nil {


### PR DESCRIPTION
Previously the test case <code>\`"Hello",true,42,23.45\`</code> would give `Hello"` as the first value, this fixes it.